### PR TITLE
Add support for snapcraft

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@types/node": "^8.0.25",
         "@types/npm": "^2.0.28",
         "@types/watch": "^1.0.0",
-        "electron-builder": "^19.23.1",
+        "electron-builder": "^19.53.0",
         "jumpfm-api": "^1.1.0"
     },
     "optionalDependencies": {
@@ -51,7 +51,8 @@
                 "build/icons/*"
             ],
             "target": [
-                "AppImage"
+                "snap",
+                "deb"
             ],
             "category": "Utility",
             "publish": "github"


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 17.10 and 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist` it will create `dist/jumpfm_1.0.5_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous jumpfm_1.0.5_amd64.snap`

Run with `jumpfm` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and [https://snapcraft.io/discover](https://snapcraft.io/discover). To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "jumpfm" name](https://dashboard.snapcraft.io/register-snap/?name=jumpfm).

You'll need the `snapcraft` command to push the snap file to the store.

    If you're on a Mac, you can `brew install snapcraft`
    If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Jumpfm out with:
`snapcraft push jumpfm_1.0.5_amd64.snap --release stable`